### PR TITLE
Update dependencies and refactor the code to fit the breaking changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         python: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.7", "pypy3.8", "pypy3.9"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
@@ -53,7 +53,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: pyo3/maturin-action@v1
         with:
           command: build
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v4
         with:
           path: $HOME/.cargo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request: {}
 
 env:
-  PY_ALL: 3.7 3.8 3.9 3.10 3.11 pypy3.9
+  PY_ALL: 3.8 3.9 3.10 3.11 3.12 pypy3.9 pypy3.10
 
 jobs:
   pytest:
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.7", "pypy3.8", "pypy3.9"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9", "pypy3.10"]
 
     steps:
       - uses: actions/checkout@v4
@@ -38,11 +38,11 @@ jobs:
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install
         run: pip install '.[dev]'
-      - name: black
-        run: black --check tests/ seahash.pyi
+      - name: ruff
+        run: ruff format --check tests/ seahash.pyi
 
   arm:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request: {}
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - main
   pull_request: {}
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,10 @@ jobs:
           python-version: "3.12"
       - name: Install
         run: pip install '.[dev]'
-      - name: ruff
+      - name: format
         run: ruff format --check tests/ seahash.pyi
+      - name: lint
+        run: ruff check tests/ seahash.pyi
 
   arm:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
     types: [published]
 
 env:
-  PY_ALL: 3.7 3.8 3.9 3.10 3.11 pypy3.7 pypy3.8 pypy3.9
-  PY_MACOS: 3.7 3.8 3.9 3.10 3.11 pypy3.9 # macOS doesn't like pypy 3.7-3.8
+  PY_ALL: 3.8 3.9 3.10 3.11 3.12 pypy3.9 pypy3.10
+  PY_MACOS: 3.8 3.9 3.10 3.11 3.12 pypy3.9 pypy3.10 # macOS doesn't like pypy 3.7-3.8
 
 jobs:
   linux:
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - uses: messense/maturin-action@v1
       with:
         manylinux: off

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: messense/maturin-action@v1
       with:
         manylinux: auto
@@ -32,7 +32,7 @@ jobs:
   sdist:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -53,7 +53,7 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: messense/maturin-action@v1
       with:
         command: build
@@ -70,7 +70,7 @@ jobs:
       matrix:
         target: [x86_64, aarch64]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: messense/maturin-action@v1
       with:
         command: build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,10 +21,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "indoc"
-version = "1.0.6"
+name = "heck"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a0bd019339e5d968b37855180087b7b9d512c5046fbd244cf8c95687927d6e"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "indoc"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "libc"
@@ -40,6 +46,15 @@ checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
  "autocfg",
  "scopeguard",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -72,24 +87,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.40"
+name = "portable-atomic"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.16.5"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6302e85060011447471887705bb7838f14aba43fcb06957d823739a496b3dc"
+checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
+ "memoffset",
  "parking_lot",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -98,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.16.5"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b65b546c35d8a3b1b2f0ddbac7c6a569d759f357f2b9df884f5d6b719152c8"
+checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -108,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.16.5"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c275a07127c1aca33031a563e384ffdd485aee34ef131116fcd58e3430d1742b"
+checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -118,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.16.5"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284fc4485bfbcc9850a6d661d627783f18d19c2ab55880b021671c4ba83e90f7"
+checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -130,20 +153,22 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.16.5"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bda0f58f73f5c5429693c96ed57f7abdb38fdfc28ae06da4101a257adb7faf"
+checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
 dependencies = [
+ "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -185,9 +210,9 @@ checksum = "cc88c725d61fc6c3132893370cac4a0200e3fedf5da8331c570664b1987f5ca2"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -208,9 +233,9 @@ checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unindent"
-version = "0.1.9"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fee519a3e570f7df377a06a1a7775cdbfb7aa460be7e08de2b1f0e69973a44"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ name = "seahash"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.16.5", features = ["extension-module"] }
+pyo3 = { version = "0.20.3", features = ["extension-module"] }
 seahash = "4.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ Issues = "https://github.com/RealOrangeOne/seahash-py/issues"
 
 [project.optional-dependencies]
 dev = [
-    "maturin",
-    "pytest",
-    "ruff"
+    "pytest==8.0.2",
+    "ruff==0.2.2"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ Issues = "https://github.com/RealOrangeOne/seahash-py/issues"
 
 [project.optional-dependencies]
 dev = [
+    "maturin",
     "pytest",
     "ruff",
-    "maturin",
     "setuptools"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "seahash"
 description = "A blazingly fast, portable hash function with proven statistical guarantees"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 readme = "README.md"
 classifiers = [
@@ -13,11 +13,11 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",
     "Typing :: Typed"
@@ -31,6 +31,8 @@ Issues = "https://github.com/RealOrangeOne/seahash-py/issues"
 
 [project.optional-dependencies]
 dev = [
-  "pytest==7.1.2",
-  "black==22.6.0"
+    "pytest",
+    "ruff",
+    "maturin",
+    "setuptools"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,5 @@ Issues = "https://github.com/RealOrangeOne/seahash-py/issues"
 dev = [
     "maturin",
     "pytest",
-    "ruff",
-    "setuptools"
+    "ruff"
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,13 +59,12 @@ mod inner {
         }
     }
 }
-use inner::{hash, hash_seeded, SeaHash};
 /// A Python module implemented in Rust.
 #[pymodule]
 fn seahash(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
-    m.add_function(wrap_pyfunction!(hash, m)?)?;
-    m.add_function(wrap_pyfunction!(hash_seeded, m)?)?;
-    m.add_class::<SeaHash>()?;
+    m.add_function(wrap_pyfunction!(inner::hash, m)?)?;
+    m.add_function(wrap_pyfunction!(inner::hash_seeded, m)?)?;
+    m.add_class::<inner::SeaHash>()?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,62 +1,65 @@
 use pyo3::prelude::*;
-use pyo3::types::PyBytes;
+mod inner {
+    use pyo3::prelude::*;
+    use pyo3::types::PyBytes;
 
-/// Hash some bytes
-#[pyfunction]
-fn hash(py: Python, buf: &[u8]) -> u64 {
-    py.allow_threads(|| seahash::hash(buf))
-}
-
-/// Hash some bytes according to a chosen seed.
-#[pyfunction]
-fn hash_seeded(py: Python, buf: &[u8], a: u64, b: u64, c: u64, d: u64) -> u64 {
-    py.allow_threads(|| seahash::hash_seeded(buf, a, b, c, d))
-}
-
-#[pyclass]
-struct SeaHash {
-    inner: Vec<u8>,
-}
-
-#[pymethods]
-impl SeaHash {
-    #[pyo3(name = "digest_size")]
-    #[classattr]
-    const DIGEST_SIZE: u8 = 8;
-
-    #[pyo3(name = "block_size")]
-    #[classattr]
-    const BLOCK_SIZE: u8 = 8;
-
-    #[new]
-    #[args(string = "Vec::new()")]
-    fn new(string: Vec<u8>) -> Self {
-        SeaHash { inner: string }
+    /// Hash some bytes
+    #[pyfunction]
+    pub(crate) fn hash(py: Python, buf: &[u8]) -> u64 {
+        py.allow_threads(|| seahash::hash(buf))
     }
 
-    pub fn update(&mut self, obj: &[u8]) {
-        self.inner.extend_from_slice(obj)
+    /// Hash some bytes according to a chosen seed.
+    #[pyfunction]
+    pub(crate) fn hash_seeded(py: Python, buf: &[u8], a: u64, b: u64, c: u64, d: u64) -> u64 {
+        py.allow_threads(|| seahash::hash_seeded(buf, a, b, c, d))
     }
 
-    pub fn digest(&self, py: Python) -> PyObject {
-        PyBytes::new(py, &self.intdigest(py).to_ne_bytes()).into()
+    #[pyclass]
+    pub(crate) struct SeaHash {
+        inner: Vec<u8>,
     }
 
-    pub fn intdigest(&self, py: Python) -> u64 {
-        hash(py, &self.inner)
-    }
+    #[pymethods]
+    impl SeaHash {
+        #[pyo3(name = "digest_size")]
+        #[classattr]
+        const DIGEST_SIZE: u8 = 8;
 
-    pub fn hexdigest(&self, py: Python) -> String {
-        format!("{:x}", self.intdigest(py))
-    }
+        #[pyo3(name = "block_size")]
+        #[classattr]
+        const BLOCK_SIZE: u8 = 8;
 
-    pub fn copy(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
+        #[new]
+        #[pyo3(signature = (string = Vec::new()))]
+        fn new(string: Vec<u8>) -> Self {
+            SeaHash { inner: string }
+        }
+
+        pub fn update(&mut self, obj: &[u8]) {
+            self.inner.extend_from_slice(obj)
+        }
+
+        pub fn digest(&self, py: Python) -> PyObject {
+            PyBytes::new(py, &self.intdigest(py).to_ne_bytes()).into()
+        }
+
+        pub fn intdigest(&self, py: Python) -> u64 {
+            hash(py, &self.inner)
+        }
+
+        pub fn hexdigest(&self, py: Python) -> String {
+            format!("{:x}", self.intdigest(py))
+        }
+
+        pub fn copy(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
         }
     }
 }
-
+use inner::{hash, hash_seeded, SeaHash};
 /// A Python module implemented in Rust.
 #[pymodule]
 fn seahash(_py: Python, m: &PyModule) -> PyResult<()> {

--- a/tests/test_seahash.py
+++ b/tests/test_seahash.py
@@ -1,4 +1,5 @@
-import pkg_resources
+from importlib.metadata import version
+
 import sys
 
 import seahash
@@ -13,7 +14,7 @@ def test_hash_seeded():
 
 
 def test_version():
-    assert seahash.__version__ == pkg_resources.get_distribution("seahash").version
+    assert seahash.__version__ == version("seahash")
 
 
 def test_hashlib_compatible():


### PR DESCRIPTION
I've created an inner mod to prevent the namespace collision that was happening with the python module. I've also taken the liberty to swap out black with ruff, since it runs faster (it's written in Rust ;) ) and it is drop-in compatible with it. It also does linting.

I've updated the tests to stop using the deprecated pkg_resources module in favor of using the importlib built-in module.

I've also dropped support for Python 3.7 since it has reached end-of-life and added Python 3.12 to the CI matrix.